### PR TITLE
fix: Fix download URL issue and add Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!CAUTION]
+> 
+> This repository has been archived, and will be deleted at a later date
+>
+> We are now using the official `xcbeautify` plugin here: https://github.com/mise-plugins/asdf-xcbeautify
+
 <div align="center">
 
 # asdf-xcbeautify [![Build](https://github.com/andrelouw/asdf-xcbeautify/actions/workflows/build.yml/badge.svg)](https://github.com/andrelouw/asdf-xcbeautify/actions/workflows/build.yml) [![Lint](https://github.com/andrelouw/asdf-xcbeautify/actions/workflows/lint.yml/badge.svg)](https://github.com/andrelouw/asdf-xcbeautify/actions/workflows/lint.yml)

--- a/bin/download
+++ b/bin/download
@@ -8,17 +8,41 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-mkdir -p "$ASDF_DOWNLOAD_PATH"
+function main () {
+	mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-# TODO: Adapt this to proper extension and adapt extracting strategy.
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION-arm64-apple-macosx.zip"
+	declare -r script_runner_cpu="$(uname -m)"
+	declare -r script_runner_os="$(uname -s)"
 
-# Download tar.gz file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "$release_file"
+	if [[ "$script_runner_os" == "Darwin" ]]; then
+		declare -r archive_suffix="apple-macosx.zip"
+	elif [[ "$script_runner_os" == "Linux" ]]; then
+		declare -r archive_suffix="unknown-linux-gnu.tar.xz"
+	else
+		fail "Unsupported OS: $script_runner_os"
+	fi
 
-#  Extract contents of tar.gz file into the download directory
-# tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
-unzip -o "$release_file" -d "$ASDF_DOWNLOAD_PATH" >/dev/null || fail "Could not extract $release_file"
+	declare -r archive_name="${TOOL_NAME}-${ASDF_INSTALL_VERSION}-${script_runner_cpu}-${archive_suffix}"
+	declare -r archive_download_path="${ASDF_DOWNLOAD_PATH}/${archive_name}"
 
-# Remove the tar.gz file since we don't need to keep it
-rm "$release_file"
+	# Download archive to the download directory
+	download_release "$ASDF_INSTALL_VERSION" "$archive_name"
+
+	# Extract contents of archive into the download directory
+	if [[ $archive_name == *.tar.xz ]]; then
+		tar --extract \
+			--file "$archive_download_path" \
+			--directory "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $archive_name"
+	elif [[ $archive_name == *.zip ]]; then
+		unzip \
+			-o "${archive_download_path}" \
+			-d "$ASDF_DOWNLOAD_PATH" >/dev/null || fail "Could not extract $archive_name"
+	else
+		fail "Unsupported archive format: $archive_name"
+	fi
+
+	# Remove the archive since we don't need to keep it
+	rm "$archive_download_path"
+}
+
+main "$@"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,12 +39,10 @@ download_release() {
 	local version filename url
 	version="$1"
 	filename="$2"
-
-	# TODO: Adapt the release URL convention for xcbeautify
-	url="$GH_REPO/releases/download/${version}/xcbeautify-${version}-arm64-apple-macosx.zip"
+	url="$GH_REPO/releases/download/${version}/${filename}"
 
 	echo "* Downloading $TOOL_NAME release $version..."
-	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+	curl "${curl_opts[@]}" -o "${ASDF_DOWNLOAD_PATH}/${filename}" -C - "$url" || fail "Could not download $url"
 }
 
 install_version() {


### PR DESCRIPTION
Hey there. The current version of this plugin had a couple issues that we needed to resolve to use it on our projects.

## Hardcoded Download URL

The download URL currently has a hardcoded `xcbeautify-1.4.0-arm64-apple-macosx.zip` string. This means trying to download any other version than `1.4.0` will fail.

This PR fixes the URL to dynamically select the archive to download based on version number, OS, and CPU architecture.

## No Linux Support

The plugin currently only supports macOS. This PR adds support for downloading the correct Linux version of xcbeautify.